### PR TITLE
Add user mail to user creation tests

### DIFF
--- a/.github/workflows/cfm-test.yaml
+++ b/.github/workflows/cfm-test.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: "Install Test Dependency"
         run: |
-          go get -u github.com/venturemark/apiserver@$(git ls-remote git://github.com/venturemark/apiserver.git HEAD | awk '{print $1;}')
+          go get -u github.com/venturemark/apiserver@$(git ls-remote git://github.com/venturemark/apiserver.git user-mail | awk '{print $1;}')
 
       - name: "Install Test Dependency"
         run: |

--- a/tst/invite_test.go
+++ b/tst/invite_test.go
@@ -89,6 +89,7 @@ func Test_Invite_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -111,6 +112,7 @@ func Test_Invite_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},
@@ -730,6 +732,7 @@ func Test_Invite_002(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -874,6 +877,7 @@ func Test_Invite_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -896,6 +900,7 @@ func Test_Invite_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},

--- a/tst/message_test.go
+++ b/tst/message_test.go
@@ -74,6 +74,7 @@ func Test_Message_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -99,6 +100,7 @@ func Test_Message_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},

--- a/tst/texupd_test.go
+++ b/tst/texupd_test.go
@@ -63,6 +63,7 @@ func Test_TexUpd_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -680,6 +681,7 @@ func Test_TexUpd_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},

--- a/tst/timeline_test.go
+++ b/tst/timeline_test.go
@@ -92,6 +92,7 @@ func Test_Timeline_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -115,6 +116,7 @@ func Test_Timeline_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},
@@ -695,6 +697,7 @@ func Test_Timeline_002(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -873,6 +876,7 @@ func Test_Timeline_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -1094,6 +1098,7 @@ func Test_Timeline_004(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -1299,6 +1304,7 @@ func Test_Timeline_005(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -1321,6 +1327,7 @@ func Test_Timeline_005(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},
@@ -1449,6 +1456,7 @@ func Test_Timeline_006(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},

--- a/tst/user_test.go
+++ b/tst/user_test.go
@@ -88,6 +88,7 @@ func Test_User_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 						Prof: []*user.CreateI_Obj_Property_Prof{
 							{
 								Desc: "Founder",
@@ -141,6 +142,7 @@ func Test_User_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},
@@ -206,6 +208,9 @@ func Test_User_001(t *testing.T) {
 		{
 			if o.Obj[0].Property.Name != "marcojelli" {
 				t.Fatal("name must be marcojelli")
+			}
+			if o.Obj[0].Property.Mail != "m@example.com" {
+				t.Fatal("mail must be m@example.com")
 			}
 		}
 
@@ -302,6 +307,9 @@ func Test_User_001(t *testing.T) {
 			if o.Obj[0].Property.Name != "marcojelli" {
 				t.Fatal("name must be marcojelli")
 			}
+			if o.Obj[0].Property.Mail != "m@example.com" {
+				t.Fatal("mail must be m@example.com")
+			}
 		}
 
 		{
@@ -350,6 +358,9 @@ func Test_User_001(t *testing.T) {
 		{
 			if o.Obj[0].Property.Name != "marcojelli" {
 				t.Fatal("name must be marcojelli")
+			}
+			if o.Obj[0].Property.Mail != "m@example.com" {
+				t.Fatal("mail must be m@example.com")
 			}
 		}
 	}
@@ -405,6 +416,9 @@ func Test_User_001(t *testing.T) {
 			if o.Obj[0].Property.Name != "marcojelli" {
 				t.Fatal("name must be marcojelli")
 			}
+			if o.Obj[0].Property.Mail != "m@example.com" {
+				t.Fatal("mail must be m@example.com")
+			}
 		}
 	}
 
@@ -433,6 +447,9 @@ func Test_User_001(t *testing.T) {
 		{
 			if o.Obj[0].Property.Name != "disreszi" {
 				t.Fatal("name must be disreszi")
+			}
+			if o.Obj[0].Property.Mail != "d@example.com" {
+				t.Fatal("mail must be d@example.com")
 			}
 		}
 	}
@@ -471,6 +488,9 @@ func Test_User_001(t *testing.T) {
 			if o.Obj[0].Property.Name != "disreszi" {
 				t.Fatal("name must be disreszi")
 			}
+			if o.Obj[0].Property.Mail != "d@example.com" {
+				t.Fatal("mail must be d@example.com")
+			}
 		}
 	}
 
@@ -507,6 +527,9 @@ func Test_User_001(t *testing.T) {
 		{
 			if o.Obj[0].Property.Name != "disreszi" {
 				t.Fatal("name must be disreszi")
+			}
+			if o.Obj[0].Property.Mail != "d@example.com" {
+				t.Fatal("mail must be d@example.com")
 			}
 		}
 	}
@@ -561,6 +584,9 @@ func Test_User_001(t *testing.T) {
 		{
 			if o.Obj[0].Property.Name != "disreszi" {
 				t.Fatal("name must be disreszi")
+			}
+			if o.Obj[0].Property.Mail != "d@example.com" {
+				t.Fatal("mail must be d@example.com")
 			}
 		}
 	}
@@ -829,6 +855,7 @@ func Test_User_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "one",
+						Mail: "o@example.com",
 					},
 				},
 			},
@@ -851,6 +878,7 @@ func Test_User_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "two",
+						Mail: "t@example.com",
 					},
 				},
 			},

--- a/tst/venture_test.go
+++ b/tst/venture_test.go
@@ -89,6 +89,7 @@ func Test_Venture_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -114,6 +115,7 @@ func Test_Venture_001(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},
@@ -1121,6 +1123,7 @@ func Test_Venture_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "marcojelli",
+						Mail: "m@example.com",
 					},
 				},
 			},
@@ -1146,6 +1149,7 @@ func Test_Venture_003(t *testing.T) {
 				{
 					Property: &user.CreateI_Obj_Property{
 						Name: "disreszi",
+						Mail: "d@example.com",
 					},
 				},
 			},


### PR DESCRIPTION
In https://github.com/venturemark/apiserver/pull/227 email became required for user creation. This PR adds email fields to user creation requests and checks that the emails match after creation.